### PR TITLE
Enable listening on all interfaces

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -61,10 +61,11 @@ app.use((req, res, next) => {
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
   const port = parseInt(process.env.PORT || '5000', 10);
+  const host = process.env.HOST || "localhost";
   server.listen({
     port,
-    host: "localhost",
+    host: host,
   }, () => {
-    log(`serving on port ${port}`);
+    log(`serving on port ${port} of ${host}`);
   });
 })();


### PR DESCRIPTION
Listen to all interfaces based on HOST env variable if it is not there, fallback to localhost only